### PR TITLE
Bump @solana/web3.js and default to http

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -342,9 +342,9 @@
       "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
     },
     "@solana/web3.js": {
-      "version": "0.18.2",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-0.18.2.tgz",
-      "integrity": "sha512-JZlNjH5vUoU2BghxgOqDpZfjXE6dSI42ioyQD6DevhQd0gfdxKBgqNKICvN3R6t58DryWUnC03qTZne+VsdL+A==",
+      "version": "0.18.4",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-0.18.4.tgz",
+      "integrity": "sha512-GIikM+///ATWkJYTwUeqBTFREqfQh2CGizKRdM5zAuZ2YahpN68q8lwoW1u3y56oq+NtzR5vX7XOOiG1k7W2nA==",
       "requires": {
         "@babel/runtime": "^7.3.1",
         "bn.js": "^5.0.0",
@@ -2188,7 +2188,7 @@
     },
     "cheerio": {
       "version": "0.22.0",
-      "resolved": "http://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
       "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
       "requires": {
         "css-select": "~1.2.0",
@@ -2661,7 +2661,7 @@
     },
     "css-select": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "requires": {
         "boolbase": "~1.0.0",
@@ -2744,7 +2744,7 @@
     },
     "deep-eql": {
       "version": "0.1.3",
-      "resolved": "http://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
       "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
       "requires": {
         "type-detect": "0.1.1"
@@ -6413,7 +6413,7 @@
     },
     "load-json-file": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -7099,7 +7099,7 @@
         },
         "load-json-file": {
           "version": "4.0.0",
-          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "requires": {
             "graceful-fs": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@material-ui/core": "^3.9.3",
     "@material-ui/icons": "^3.0.2",
-    "@solana/web3.js": "0.18.2",
+    "@solana/web3.js": "^0.18.4",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
     "babel-eslint": "^10.0.2",

--- a/program-bpf-rust/Cargo.toml
+++ b/program-bpf-rust/Cargo.toml
@@ -17,7 +17,7 @@ solana-sdk-bpf-utils = { path = "../node_modules/@solana/web3.js/bpf-sdk/rust/ru
 solana-sdk-bpf-no-std = { path = "../node_modules/@solana/web3.js/bpf-sdk/rust/rust-no-std" }
 
 [dev_dependencies]
-solana-sdk-bpf-test = { path = "../node_modules/@solana/web3.js/bpf-sdk/rust/rust-test", version = "0.17.0" }
+solana-sdk-bpf-test = { path = "../node_modules/@solana/web3.js/bpf-sdk/rust/rust-test" }
 
 [workspace]
 members = []

--- a/urls.js
+++ b/urls.js
@@ -3,7 +3,7 @@
 import {testnetChannelEndpoint} from '@solana/web3.js';
 
 export let url = process.env.LIVE
-  ? testnetChannelEndpoint(process.env.CHANNEL || 'beta')
+  ? testnetChannelEndpoint(process.env.CHANNEL || 'beta', false)
   : 'http://localhost:8899';
 
 export let walletUrl =


### PR DESCRIPTION
There are cert errors when using https to access the testnet api, we should use http in the meantime to fix the broken app

```
createMessageFeed failed: FetchError: request to https://edge.testnet.solana.com:8443/ failed, reason: unable to verify the first certificate
```